### PR TITLE
Cox::LibSodium::NONCE_BYTES points to the wrong function

### DIFF
--- a/src/cox/lib_sodium.cr
+++ b/src/cox/lib_sodium.cr
@@ -13,7 +13,7 @@ module Cox
 
     PUBLIC_KEY_BYTES  = crypto_box_publickeybytes()
     SECRET_KEY_BYTES  = crypto_box_secretkeybytes()
-    NONCE_BYTES       = crypto_box_macbytes()
+    NONCE_BYTES       = crypto_box_noncebytes()
     MAC_BYTES         = crypto_box_macbytes()
     PUBLIC_SIGN_BYTES = crypto_sign_publickeybytes()
     SECRET_SIGN_BYTES = crypto_sign_secretkeybytes()


### PR DESCRIPTION
When I try to instantiate a `Cox::Nonce` manually, it was raising because it was expecting 16 bytes. The nonce is supposed to be 24 bytes.